### PR TITLE
Z01R: bind mount hex-edited ril blobs to read the fake property

### DIFF
--- a/lineage_Z01R.mk
+++ b/lineage_Z01R.mk
@@ -27,7 +27,7 @@ $(call inherit-product, vendor/lineage/config/common_full_phone.mk)
 
 PRODUCT_NAME := lineage_Z01R
 PRODUCT_DEVICE := Z01R
-PRODUCT_MANUFACTURER := unknown
+PRODUCT_MANUFACTURER := asus
 PRODUCT_BRAND := asus
 
 PRODUCT_GMS_CLIENTID_BASE := android-asus

--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -1,6 +1,8 @@
 on init
     mount none /system/etc/audio_policy_configuration.xml /vendor/etc/audio/audio_policy_configuration.xml bind
     mount none /system/lib64/hw/power.qcom.so /vendor/lib64/hw/power.qcom.so bind
+    mount none /system/lib/libril-qc-hal-qmi.so /vendor/lib/libril-qc-hal-qmi.so bind
+    mount none /system/lib64/libril-qc-hal-qmi.so /vendor/lib64/libril-qc-hal-qmi.so bind
 
     # default is root radio 0440
     chmod 0644 /proc/cmdline

--- a/system_prop.mk
+++ b/system_prop.mk
@@ -77,3 +77,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     telephony.lteOnCdmaDevice=1 \
     DEVICE_PROVISIONED=1 \
     ro.telephony.default_network=22,22
+
+# Asus RIL Hax
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hexedit.manufacturer=unknown


### PR DESCRIPTION
* since a rough testing shows our vendor ril blobs are reading ro.product.manufacturer, which causing issues when it's "Asus" or "asus" (weird huh?).
* so hex-edit the blobs to direct to our fake property: ro.hexedit.manufacturer.
* bind mount it from device side init scripts.

* set PRODUCT_MANUFACTURER back to "asus" again.